### PR TITLE
Github actions updates for apps-helm-charts repo

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -57,7 +57,7 @@ jobs:
         allow-repeats: false
     - name: Notify Slack
       uses: 8398a7/action-slack@v3
-      if: always() # Pick up events even if the job fails or is canceled.
+      if: failure() # Only alert on failure
       with:
         status: ${{ job.status }}
         fields: repo,author,action,eventName,ref,workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,13 +71,25 @@ jobs:
         git config --local user.name "jupiterone-helm-chart-bot"
         git status 
         git add ${CHART_PATH}/Chart.yaml
-        git commit -m "[skip-ci] Updated application helm chart version to: ${{ steps.gitversion.outputs.semVer }}"     
-    - name: Notify Slack
+        git commit -m "[skip-ci] Updated application helm chart version to: ${{ steps.gitversion.outputs.semVer }}"
+    - name: Notify Slack - Failure
       uses: 8398a7/action-slack@v3
-      if: always() # Pick up events even if the job fails or is canceled.
+      if: failure() # Only alert on failure
       with:
+        text: "Oh barnacles. It looks like a failure occurred when releasing helm chart apps-helm-charts/application on version: ${{ steps.gitversion.outputs.semVer }}"
+        status: ${{ job.status }}
+        fields: repo,author,action,eventName,ref,workflow
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SRE_TEAM_SLACK_WEBHOOK }}    
+    - name: Notify Slack - Success
+      uses: 8398a7/action-slack@v3
+      if: success() # Only alert on success
+      with:
+        text: "Just a heads up, apps-helm-charts/application has published a new helm chart release, ${{ steps.gitversion.outputs.semVer }}, that is now available at: https://jupiterone.github.io/apps-helm-charts"
         status: ${{ job.status }}
         fields: repo,author,action,eventName,ref,workflow
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLACK_WEBHOOK_URL: ${{ secrets.SRE_TEAM_SLACK_WEBHOOK }}
+


### PR DESCRIPTION
Update github actions to only publish github actions pr on failure

Updated github actions release workflow to send differently formatted messages for success/failure status on release workflow run.

Fixes pr build failure