### PR TITLE
Address breaking changes in helm/chart-releaser-action: Updates git origin url

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,6 +116,8 @@ jobs:
         git commit -m "[skip-ci] Updated application helm chart version to: ${{ steps.gitversion.outputs.majorMinorPatch }}"
         git push origin
         echo "GITHUB_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      env: 
+        TOKEN: ${{ steps.get_token.outputs.app_token }}  
     - name: Tag Version
       id: tag_version
       if: ${{ env.SHOULD_UPDATE_CHART_VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,6 @@ jobs:
       run: gpg -K
     - name: Configure Git
       run: |
-        git remote set-url origin https://x-access-token:${{env.TOKEN}}@github.com/$GITHUB_REPOSITORY
         git config user.name "j1-sre-github-automation"
         git config user.email "j1-sre-github-automation@users.noreply.github.com"
       env: 
@@ -111,7 +110,8 @@ jobs:
     - name: Commit and push files
       if: ${{ env.SHOULD_UPDATE_CHART_VERSION }}
       run: |
-        git status 
+        git status
+        git remote set-url origin https://x-access-token:${{env.TOKEN}}@github.com/$GITHUB_REPOSITORY
         git add charts/application/Chart.yaml
         git commit -m "[skip-ci] Updated application helm chart version to: ${{ steps.gitversion.outputs.majorMinorPatch }}"
         git push origin


### PR DESCRIPTION
Version 1.2.1 of helm/chart-releaser-action adds logic that prepends the github access token to the git origin remote, so we need to ensure that our configured git origin url (before the chart-releaser is run does not contain our access token per [this](https://github.com/helm/chart-releaser/commit/30eafb2b1479c31a08ddd1f05976319ad54aebe2#diff-7c3aacfe3adda2f30498118e88d5ead94c6817f537490cb0a3d0de3c98fbe8beR72) )
